### PR TITLE
[fix] fix license check for redecuce-dependency-pom.xml while shade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,7 @@ under the License.
                         <exclude>docs/static/js/anchor.min.js</exclude>
                         <exclude>docs/layouts/shortcodes/generated/**</exclude>
                         <exclude>**/*.svg</exclude>
+                        <exclude>*/dependency-reduced-pom.xml</exclude>
                         <!-- Bundled license files -->
                         <exclude>**/LICENSE*</exclude>
                         <!-- artifacts created during release process -->


### PR DESCRIPTION
reduce-dependency-pom.xml is generated by shade plugin, we don't need to check its license