### PR TITLE
Use paimon shade guava

### DIFF
--- a/paimon-presto-0.236/src/main/java/org/apache/paimon/presto/PrestoSplit.java
+++ b/paimon-presto-0.236/src/main/java/org/apache/paimon/presto/PrestoSplit.java
@@ -18,13 +18,13 @@
 
 package org.apache.paimon.presto;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 import org.apache.paimon.table.source.Split;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 

--- a/paimon-presto-common/pom.xml
+++ b/paimon-presto-common/pom.xml
@@ -129,7 +129,6 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-bundle</include>
-                                    <include>com.google.guava:guava</include>
                                     <include>org.slf4j:slf4j-api</include>
                                     <include>org.apache.logging.log4j:log4j-api</include>
                                     <include>org.apache.logging.log4j:log4j-core</include>

--- a/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoFilterConverter.java
+++ b/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoFilterConverter.java
@@ -21,6 +21,7 @@ package org.apache.paimon.presto;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.shade.guava30.com.google.common.base.Preconditions;
 import org.apache.paimon.types.RowType;
 
 import com.facebook.presto.common.predicate.Domain;
@@ -42,7 +43,6 @@ import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
-import com.google.common.base.Preconditions;
 import io.airlift.slice.Slice;
 
 import java.math.BigDecimal;

--- a/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoMetadata.java
+++ b/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoMetadata.java
@@ -26,6 +26,7 @@ import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.schema.Schema;
 import org.apache.paimon.security.SecurityContext;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 import org.apache.paimon.utils.InstantiationUtil;
 import org.apache.paimon.utils.StringUtils;
 
@@ -46,7 +47,6 @@ import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.statistics.ComputedStatistics;
-import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
 import java.io.IOException;

--- a/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoPageSourceBase.java
+++ b/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoPageSourceBase.java
@@ -25,6 +25,7 @@ import org.apache.paimon.data.InternalMap;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.reader.RecordReader;
+import org.apache.paimon.shade.guava30.com.google.common.base.Verify;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypeChecks;
 import org.apache.paimon.utils.InternalRowUtils;
@@ -45,7 +46,6 @@ import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.PrestoException;
-import com.google.common.base.Verify;
 import io.airlift.slice.Slice;
 
 import java.io.IOException;

--- a/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoSplit.java
+++ b/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoSplit.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.presto;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 import org.apache.paimon.table.source.Split;
 
 import com.facebook.presto.spi.ConnectorSplit;
@@ -25,7 +26,6 @@ import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.NodeProvider;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 

--- a/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoTableLayoutHandle.java
+++ b/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoTableLayoutHandle.java
@@ -18,12 +18,13 @@
 
 package org.apache.paimon.presto;
 
+import org.apache.paimon.shade.guava30.com.google.common.base.MoreObjects;
+
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.MoreObjects;
 
 import java.util.Objects;
 

--- a/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoTransactionManager.java
+++ b/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoTransactionManager.java
@@ -18,9 +18,10 @@
 
 package org.apache.paimon.presto;
 
+import org.apache.paimon.shade.guava30.com.google.common.base.Preconditions;
+
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.google.common.base.Preconditions;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoTypeUtils.java
+++ b/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoTypeUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.presto;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.BinaryType;
@@ -54,7 +55,6 @@ import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
-import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Objects;

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoColumnHandleTest.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoColumnHandleTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.presto;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.types.VarCharType;
 import org.apache.paimon.utils.JsonSerdeUtil;
 
@@ -27,7 +28,6 @@ import com.facebook.airlift.json.JsonObjectMapperProvider;
 import com.facebook.airlift.json.ObjectMapperProvider;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.type.TypeDeserializer;
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoDistributedQueryTest.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoDistributedQueryTest.java
@@ -18,10 +18,11 @@
 
 package org.apache.paimon.presto;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
 import com.facebook.presto.Session;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
-import com.google.common.collect.ImmutableMap;
 import org.testng.SkipException;
 
 /** The test of PrestoDistributedQuery. */

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoFilterConverterTest.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoFilterConverterTest.java
@@ -21,6 +21,7 @@ package org.apache.paimon.presto;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
@@ -30,7 +31,6 @@ import com.facebook.presto.common.predicate.Range;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.predicate.ValueSet;
 import com.facebook.presto.common.type.CharType;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
 import org.junit.jupiter.api.Test;
 

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoPluginTest.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoPluginTest.java
@@ -18,11 +18,12 @@
 
 package org.apache.paimon.presto;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.facebook.presto.testing.TestingConnectorContext;
-import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoQueryRunner.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoQueryRunner.java
@@ -18,12 +18,13 @@
 
 package org.apache.paimon.presto;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.log.Logging;
 import com.facebook.presto.Session;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.facebook.presto.tpch.TpchPlugin;
-import com.google.common.collect.ImmutableMap;
 
 import java.nio.file.Path;
 import java.util.Map;

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoTypeTest.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/PrestoTypeTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.presto;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
@@ -45,7 +46,6 @@ import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
-import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/paimon-prestosql-common/pom.xml
+++ b/paimon-prestosql-common/pom.xml
@@ -146,7 +146,6 @@ under the License.
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.paimon:paimon-bundle</include>
-                                    <include>com.google.guava:guava</include>
                                     <include>org.xerial.snappy:snappy-java</include>
                                     <include>org.slf4j:slf4j-api</include>
                                     <include>org.apache.logging.log4j:log4j-api</include>

--- a/paimon-prestosql-common/src/main/java/org/apache/paimon/prestosql/PrestoSqlTableOptions.java
+++ b/paimon-prestosql-common/src/main/java/org/apache/paimon/prestosql/PrestoSqlTableOptions.java
@@ -18,7 +18,8 @@
 
 package org.apache.paimon.prestosql;
 
-import com.google.common.collect.ImmutableList;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
+
 import io.prestosql.spi.session.PropertyMetadata;
 import io.prestosql.spi.type.ArrayType;
 

--- a/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/PrestoSqlQueryRunner.java
+++ b/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/PrestoSqlQueryRunner.java
@@ -18,7 +18,8 @@
 
 package org.apache.paimon.prestosql;
 
-import com.google.common.collect.ImmutableMap;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
 import io.airlift.log.Logger;
 import io.prestosql.Session;
 import io.prestosql.plugin.tpch.TpchPlugin;

--- a/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlColumnHandle.java
+++ b/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlColumnHandle.java
@@ -18,9 +18,9 @@
 
 package org.apache.paimon.prestosql;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.types.DataTypes;
 
-import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;

--- a/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlConnectorFactory.java
+++ b/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlConnectorFactory.java
@@ -18,7 +18,8 @@
 
 package org.apache.paimon.prestosql;
 
-import com.google.common.collect.ImmutableMap;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
 import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorFactory;
 import io.prestosql.testing.TestingConnectorContext;

--- a/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlFilterConverter.java
+++ b/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlFilterConverter.java
@@ -21,11 +21,11 @@ package org.apache.paimon.prestosql;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 
-import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.Range;

--- a/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlPlugin.java
+++ b/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlPlugin.java
@@ -18,7 +18,8 @@
 
 package org.apache.paimon.prestosql;
 
-import com.google.common.collect.ImmutableMap;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
 import io.prestosql.spi.Plugin;
 import io.prestosql.spi.connector.Connector;
 import io.prestosql.spi.connector.ConnectorFactory;

--- a/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlType.java
+++ b/paimon-prestosql-common/src/test/java/org/apache/paimon/prestosql/TestPrestoSqlType.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.prestosql;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.Lists;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.DataTypes;
@@ -25,7 +26,6 @@ import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.TimeType;
 import org.apache.paimon.types.VarCharType;
 
-import com.google.common.collect.Lists;
 import io.prestosql.spi.type.ArrayType;
 import io.prestosql.spi.type.BigintType;
 import io.prestosql.spi.type.BooleanType;

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@ under the License.
         <junit5.version>5.8.1</junit5.version>
         <slf4j.version>1.7.25</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
-        <guava.version>31.1-jre</guava.version>
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <findbugs.version>1.3.9</findbugs.version>
         <maven.checkstyle.version>3.1.2</maven.checkstyle.version>
@@ -115,12 +114,6 @@ under the License.
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit5.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
We are attempting to use Paimon's Hive catalog within Presto. To achieve this, we need to add some additional dependencies, such as Hive or Hadoop. Different users may have different versions of Hive and Hadoop, and these dependencies may also include different versions of the Guava package, which can easily lead to conflicts. The usual approach is to use Shade to relocate our Guava version. However, I noticed that the Paimon-bundle already contains a shaded version of Guava, so we can simply use it.