### PR TITLE
Fix long decimal error

### DIFF
--- a/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoPageSourceBase.java
+++ b/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoPageSourceBase.java
@@ -245,7 +245,7 @@ public abstract class PrestoPageSourceBase implements ConnectorPageSource {
             Verify.verify(isLongDecimal(type), "The type should be long decimal");
             DecimalType decimalType = (DecimalType) type;
             BigDecimal decimal = ((Decimal) value).toBigDecimal();
-            type.writeObject(output, Decimals.encodeScaledValue(decimal, decimalType.getScale()));
+            type.writeSlice(output, Decimals.encodeScaledValue(decimal, decimalType.getScale()));
         } else {
             throw new PrestoException(
                     GENERIC_INTERNAL_ERROR,


### PR DESCRIPTION
We have a paimon table like:
```
 CREATE TABLE `test_decimal`( 
 c1 decimal(20,0),
 c2 decimal(6,3)
  ) 
 ROW FORMAT SERDE 
 'org.apache.paimon.hive.PaimonSerDe' 
 STORED BY 
 'org.apache.paimon.hive.PaimonStorageHandler' ;
``` 
when we query it by prestodb:
```
java.lang.UnsupportedOperationException: com.facebook.presto.common.type.LongDecimalType
	at com.facebook.presto.common.type.AbstractType.writeObject(AbstractType.java:170)
	at org.apache.paimon.presto.PrestoPageSourceBase.writeObject(PrestoPageSourceBase.java:248)
	at org.apache.paimon.presto.PrestoPageSourceBase.appendTo(PrestoPageSourceBase.java:220)
	at org.apache.paimon.presto.PrestoPageSourceBase.nextPage(PrestoPageSourceBase.java:154)
	at org.apache.paimon.presto.PrestoPageSourceBase.lambda$getNextPage$0(PrestoPageSourceBase.java:127)
	at org.apache.paimon.presto.ClassLoaderUtils.runWithContextClassLoader(ClassLoaderUtils.java:30)
	at org.apache.paimon.presto.PrestoPageSourceBase.getNextPage(PrestoPageSourceBase.java:124)
	at com.facebook.presto.operator.TableScanOperator.getOutput(TableScanOperator.java:266)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:426)
	at com.facebook.presto.operator.Driver.lambda$processFor$9(Driver.java:309)
	at com.facebook.presto.operator.Driver.tryWithLock(Driver.java:730)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:302)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1079)
	at com.facebook.presto.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:165)
	at com.facebook.presto.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:603)
	at com.facebook.presto.$gen.Presto_0_280_a95c1b4____20231207_111100_1.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

After this pr we can query decimal type normally:
![image](https://github.com/apache/incubator-paimon-presto/assets/45056332/e0ef8bcd-2614-4b33-b98f-f66afd089d96)

