### PR TITLE
fix-predicate-timestamp-and-decimal

### DIFF
--- a/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoFilterConverter.java
+++ b/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoFilterConverter.java
@@ -34,6 +34,7 @@ import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DateType;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.Decimals;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.MapType;
@@ -48,7 +49,6 @@ import com.facebook.presto.common.type.VarcharType;
 import io.airlift.slice.Slice;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -213,7 +213,7 @@ public class PrestoFilterConverter {
         }
 
         if (type instanceof TimeType) {
-            return Timestamp.fromEpochMillis((Long) prestoNativeValue);
+            return (int) ((long) prestoNativeValue / 1_000);
         }
 
         if (type instanceof TimestampType) {
@@ -248,7 +248,10 @@ public class PrestoFilterConverter {
                         BigDecimal.valueOf((long) prestoNativeValue)
                                 .movePointLeft(decimalType.getScale());
             } else {
-                bigDecimal = new BigDecimal((BigInteger) prestoNativeValue, decimalType.getScale());
+                bigDecimal =
+                        new BigDecimal(
+                                Decimals.decodeUnscaledValue((Slice) prestoNativeValue),
+                                decimalType.getScale());
             }
             return Decimal.fromBigDecimal(
                     bigDecimal, decimalType.getPrecision(), decimalType.getScale());

--- a/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoPageSourceBase.java
+++ b/paimon-presto-common/src/main/java/org/apache/paimon/presto/PrestoPageSourceBase.java
@@ -54,6 +54,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -206,7 +207,13 @@ public abstract class PrestoPageSourceBase implements ConnectorPageSource {
                 prestoType.writeLong(
                         output, encodeShortScaledValue(decimal, decimalType.getScale()));
             } else if (prestoType.equals(TIMESTAMP)) {
-                prestoType.writeLong(output, ((Timestamp) value).toSQLTimestamp().getTime());
+                prestoType.writeLong(
+                        output,
+                        ((Timestamp) value)
+                                .toLocalDateTime()
+                                .atZone(ZoneId.systemDefault())
+                                .toInstant()
+                                .toEpochMilli());
             } else if (prestoType.equals(TIME)) {
                 prestoType.writeLong(output, (int) value * 1_000);
             } else {

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
@@ -182,7 +182,6 @@ public class TestPrestoITCase {
                                     LocalDateTime.parse("2023-01-01T01:01:01.123")),
                             Timestamp.fromMicros(
                                     1672534861123000L))); // 2023-01-01T01:01:01.123 Pacific/Apia
-            // conversion
             commit.commit(0, writer.prepareCommit(true, 0));
         }
 

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
@@ -46,6 +46,7 @@ import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.testing.TestingSession;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -240,12 +241,15 @@ public class TestPrestoITCase {
         return new SimpleTableTestHelper(tablePath, rowType);
     }
 
-    @BeforeTest
-    public void init() throws Exception {
+    @BeforeSuite
+    public void setup() throws Exception {
         // Set the presto-tests of default Timezone key for the current jvm.
         // Because ut related to timestamps will be affected by the default Timezone.
         TimeZone.setDefault(TimeZone.getTimeZone(TestingSession.DEFAULT_TIME_ZONE_KEY.getId()));
+    }
 
+    @BeforeTest
+    public void init() throws Exception {
         queryRunner = createQueryRunner();
     }
 

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
@@ -43,10 +43,13 @@ import org.apache.paimon.types.VarCharType;
 
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.TestingSession;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.time.LocalDateTime;
@@ -54,6 +57,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.UUID;
 
 import static com.facebook.airlift.testing.Closeables.closeAllSuppress;
@@ -158,7 +162,9 @@ public class TestPrestoITCase {
             Path tablePath5 = new Path(warehouse, "default.db/test_timestamp");
             RowType rowType =
                     new RowType(
-                            Collections.singletonList(new DataField(0, "ts", new TimestampType())));
+                            Arrays.asList(
+                                    new DataField(0, "ts", new TimestampType()),
+                                    new DataField(1, "ts_long_0", new TimestampType())));
             new SchemaManager(LocalFileIO.create(), tablePath5)
                     .createTable(
                             new Schema(
@@ -173,7 +179,10 @@ public class TestPrestoITCase {
             writer.write(
                     GenericRow.of(
                             Timestamp.fromLocalDateTime(
-                                    LocalDateTime.parse("2023-01-01T01:01:01.123"))));
+                                    LocalDateTime.parse("2023-01-01T01:01:01.123")),
+                            Timestamp.fromMicros(
+                                    1672534861123000L))); // 2023-01-01T01:01:01.123 Pacific/Apia
+            // conversion
             commit.commit(0, writer.prepareCommit(true, 0));
         }
 
@@ -234,7 +243,17 @@ public class TestPrestoITCase {
 
     @BeforeTest
     public void init() throws Exception {
+        // Set the presto-tests of default Timezone key for the current jvm.
+        // Because ut related to timestamps will be affected by the default Timezone.
+        TimeZone.setDefault(TimeZone.getTimeZone(TestingSession.DEFAULT_TIME_ZONE_KEY.getId()));
+
         queryRunner = createQueryRunner();
+    }
+
+    @AfterTest
+    public void clear() throws IOException {
+        // TODO Delete default.db
+        queryRunner.close();
     }
 
     @Test
@@ -279,18 +298,180 @@ public class TestPrestoITCase {
                 .isEqualTo("[[1, 1, 3, 3], [2, 3, 3, 3]]");
     }
 
-    // Due to the inconsistency between the testing behavior and the real production environment,
-    // we are temporarily disabling timestamp testing here.
-    @Test(enabled = false)
+    @Test
     public void testTimestampFormat() throws Exception {
-        assertThat(sql("SELECT ts FROM paimon.default.test_timestamp"))
-                .isEqualTo("[[2023-01-01T01:01:01.123]]");
+        assertThat(
+                        sql(
+                                "SELECT ts, format_datetime(ts, 'yyyy-MM-dd HH:mm:ss') FROM paimon.default.test_timestamp"))
+                .isEqualTo("[[2023-01-01T01:01:01.123, 2023-01-01 01:01:01]]");
     }
 
     @Test
     public void testDecimal() throws Exception {
         assertThat(sql("SELECT c1, c2 FROM paimon.default.test_decimal"))
                 .isEqualTo("[[10000000000, 123.456]]");
+    }
+
+    @Test
+    public void testTimestampPredicateWithTimezone() throws Exception {
+        // Use other Timezone unable to find data, as UTC.
+        assertThat(
+                        sql(
+                                "SELECT ts, ts_long_0 FROM paimon.default.test_timestamp "
+                                        + "where ts = TIMESTAMP '2023-01-01 01:01:01.123 UTC'"))
+                .isEqualTo("[]");
+
+        // This Pacific/Apia is presto-tests default Timezone.
+        assertThat(
+                        sql(
+                                "SELECT ts, ts_long_0 FROM paimon.default.test_timestamp "
+                                        + "where ts = TIMESTAMP '2023-01-01 01:01:01.123 Pacific/Apia'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123, 2023-01-01T01:01:01.123]]");
+    }
+
+    @Test
+    public void testTimestampPredicateEq() throws Exception {
+        assertThat(
+                        sql(
+                                "SELECT ts, ts_long_0 FROM paimon.default.test_timestamp "
+                                        + "where ts = TIMESTAMP '2023-01-01 01:01:01.123'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123, 2023-01-01T01:01:01.123]]");
+
+        assertThat(
+                        sql(
+                                "SELECT ts, ts_long_0 FROM paimon.default.test_timestamp "
+                                        + "where ts = TIMESTAMP '2023-01-01 01:01:01.123'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123, 2023-01-01T01:01:01.123]]");
+
+        assertThat(
+                        sql(
+                                "SELECT ts, ts_long_0 FROM paimon.default.test_timestamp "
+                                        + "WHERE ts_long_0 = date_add("
+                                        + "'millisecond', "
+                                        + "CAST(1672484461123 % 1000 AS INTEGER), "
+                                        + "from_unixtime(CAST(1672484461123 / 1000 AS BIGINT))"
+                                        + ")"))
+                .isEqualTo("[[2023-01-01T01:01:01.123, 2023-01-01T01:01:01.123]]");
+
+        assertThat(
+                        sql(
+                                "SELECT ts, ts_long_0 FROM paimon.default.test_timestamp "
+                                        + "WHERE ts = TIMESTAMP '2023-01-01 01:01:01.123' "
+                                        + "AND ts_long_0 = date_add("
+                                        + "'millisecond', "
+                                        + "CAST(1672484461123 % 1000 AS INTEGER), "
+                                        + "from_unixtime(CAST(1672484461123 / 1000 AS BIGINT)))"))
+                .isEqualTo("[[2023-01-01T01:01:01.123, 2023-01-01T01:01:01.123]]");
+    }
+
+    @Test
+    public void testTimestampPredicate() throws Exception {
+        // Test gt and gte.
+        assertThat(
+                        sql(
+                                "SELECT ts FROM paimon.default.test_timestamp "
+                                        + "where ts > TIMESTAMP '2023-01-01 01:01:01'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123]]");
+
+        assertThat(
+                        sql(
+                                "SELECT ts FROM paimon.default.test_timestamp "
+                                        + "where ts >= TIMESTAMP '2023-01-01 01:01:01.123'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123]]");
+
+        // Test lt and lte.
+        assertThat(
+                        sql(
+                                "SELECT ts FROM paimon.default.test_timestamp "
+                                        + "where ts < TIMESTAMP '2023-01-01 01:01:02'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123]]");
+
+        assertThat(
+                        sql(
+                                "SELECT ts FROM paimon.default.test_timestamp "
+                                        + "where ts <= TIMESTAMP '2023-01-01 01:01:01.123'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123]]");
+
+        // Test gt and lt.
+        assertThat(
+                        sql(
+                                "SELECT ts FROM paimon.default.test_timestamp "
+                                        + "where ts > TIMESTAMP '2023-01-01 01:01:00' "
+                                        + "and ts < TIMESTAMP '2023-01-01 01:01:02'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123]]");
+
+        // Test gt and lte.
+        assertThat(
+                        sql(
+                                "SELECT ts FROM paimon.default.test_timestamp "
+                                        + "where ts > TIMESTAMP '2023-01-01 01:01:00' "
+                                        + "and ts <= TIMESTAMP '2023-01-01 01:01:01.123'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123]]");
+
+        // Test gte and lte.
+        assertThat(
+                        sql(
+                                "SELECT ts FROM paimon.default.test_timestamp "
+                                        + "where ts >= TIMESTAMP '2023-01-01 01:01:01.123' "
+                                        + "and ts <= TIMESTAMP '2023-01-01 01:01:01.123'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123]]");
+
+        // Test gte and lt.
+        assertThat(
+                        sql(
+                                "SELECT ts FROM paimon.default.test_timestamp "
+                                        + "where ts >= TIMESTAMP '2023-01-01 01:01:01' "
+                                        + "and ts < TIMESTAMP '2023-01-01 01:01:02'"))
+                .isEqualTo("[[2023-01-01T01:01:01.123]]");
+    }
+
+    @Test
+    public void testDecimalPredicate() throws Exception {
+        // Test eq.
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 = 123.456"))
+                .isEqualTo("[[123.456]]");
+
+        // Test gt and gte.
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 > 123"))
+                .isEqualTo("[[123.456]]");
+
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 > 123.455"))
+                .isEqualTo("[[123.456]]");
+
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 >= 123"))
+                .isEqualTo("[[123.456]]");
+
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 >= 123.456"))
+                .isEqualTo("[[123.456]]");
+
+        // Test lt and lte.
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 < 124"))
+                .isEqualTo("[[123.456]]");
+
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 < 123.457"))
+                .isEqualTo("[[123.456]]");
+
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 <= 124"))
+                .isEqualTo("[[123.456]]");
+
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 <= 123.457"))
+                .isEqualTo("[[123.456]]");
+
+        // Test gt and lt.
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 > 123 and c2 < 666"))
+                .isEqualTo("[[123.456]]");
+
+        // Test gt and lte.
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 > 123 and c2 <= 666"))
+                .isEqualTo("[[123.456]]");
+
+        // Test gte and lte.
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 >= 123 and c2 <= 666"))
+                .isEqualTo("[[123.456]]");
+
+        // Test gte and lt.
+        assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 >= 123 and c2 < 666"))
+                .isEqualTo("[[123.456]]");
     }
 
     private String sql(String sql) throws Exception {

--- a/paimon-presto-common/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
+++ b/paimon-presto-common/src/test/java/org/apache/paimon/presto/TestPrestoITCase.java
@@ -430,6 +430,9 @@ public class TestPrestoITCase {
         assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 = 123.456"))
                 .isEqualTo("[[123.456]]");
 
+        assertThat(sql("SELECT c1 FROM paimon.default.test_decimal where c1 = 10000000000"))
+                .isEqualTo("[[10000000000]]");
+
         // Test gt and gte.
         assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 > 123"))
                 .isEqualTo("[[123.456]]");
@@ -443,6 +446,9 @@ public class TestPrestoITCase {
         assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 >= 123.456"))
                 .isEqualTo("[[123.456]]");
 
+        assertThat(sql("SELECT c1 FROM paimon.default.test_decimal where c1 >= 10000000000"))
+                .isEqualTo("[[10000000000]]");
+
         // Test lt and lte.
         assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 < 124"))
                 .isEqualTo("[[123.456]]");
@@ -455,6 +461,9 @@ public class TestPrestoITCase {
 
         assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 <= 123.457"))
                 .isEqualTo("[[123.456]]");
+
+        assertThat(sql("SELECT c1 FROM paimon.default.test_decimal where c1 <= 10000000000"))
+                .isEqualTo("[[10000000000]]");
 
         // Test gt and lt.
         assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 > 123 and c2 < 666"))
@@ -471,6 +480,11 @@ public class TestPrestoITCase {
         // Test gte and lt.
         assertThat(sql("SELECT c2 FROM paimon.default.test_decimal where c2 >= 123 and c2 < 666"))
                 .isEqualTo("[[123.456]]");
+
+        assertThat(
+                        sql(
+                                "SELECT c1 FROM paimon.default.test_decimal where c1 >= 10000000000 and c1 < 10000000001"))
+                .isEqualTo("[[10000000000]]");
     }
 
     private String sql(String sql) throws Exception {


### PR DESCRIPTION
fix #30 

presto paimon connector when the predicate pushdown and read data, the data in the file was converted to paimon Timestamp type, the default time zone was not used with the system default, so the error was caused.

<img width="2535" alt="image" src="https://github.com/apache/incubator-paimon-presto/assets/8359848/1bc416ba-9eab-4842-9d59-ee3363006d2b">

---

TimeType will also have problems, fix it in the next pr.
